### PR TITLE
Bloc fonctionnalités : migration du layout liste

### DIFF
--- a/assets/sass/style/blocks.sass
+++ b/assets/sass/style/blocks.sass
@@ -30,28 +30,39 @@
                         @include media-breakpoint-up(desktop)
                             font-size: $body-size-desktop
     .block-features
-        ul
-            li
+        .features
+            .feature
                 background-color: $orange-main
                 padding: var(--grid-gutter)
                 .name
                     @include h3
-                figure 
-                    picture.is-png 
-                        padding-top: 0
+
+        &--list
+            .features
+                .feature
+                    figure
                         img
-                            max-width: 100%
-                            margin: auto
-                @include in-page-without-sidebar        
-                    text-align: center
-                    width: columns(4)
-                    + li
+                            aspect-ratio: auto
+                    + .feature
                         margin-top: var(--grid-gutter)
-                        margin-top: 0
-            @include in-page-without-sidebar    
-                display: flex
-                flex-wrap: wrap
-                justify-content: center
+
+        &--grid
+            .features
+                .feature
+                    figure 
+                        picture.is-png 
+                            padding-top: 0
+                            img
+                                max-width: 100%
+                                margin: auto
+                    
+                @include in-page-without-sidebar    
+                    display: flex
+                    flex-wrap: wrap
+                    justify-content: center  
+                    .feature   
+                        text-align: center
+                        width: columns(4)
 
     .block-pages
         &--list

--- a/assets/sass/style/blocks.sass
+++ b/assets/sass/style/blocks.sass
@@ -46,6 +46,15 @@
                     + .feature
                         margin-top: var(--grid-gutter)
 
+                    @include in-page-with-sidebar
+                        .feature-content
+                            display: block
+                            .name,
+                            .feature-description
+                                width: 100%
+                            .feature-description
+                                margin-left: 0
+
         &--grid
             .features
                 .feature

--- a/content/en/pages/projects/prospera/_index.html
+++ b/content/en/pages/projects/prospera/_index.html
@@ -131,10 +131,10 @@ contents:
         heading: 3
 
     data:
-      layout: grid
+      layout: list
 
       options:
-        icons: true
+        icons: false
 
       elements:
         - 

--- a/content/en/pages/projects/prospera/_index.html
+++ b/content/en/pages/projects/prospera/_index.html
@@ -131,10 +131,10 @@ contents:
         heading: 3
 
     data:
-      layout: list
+      layout: grid
 
       options:
-        icons: false
+        icons: true
 
       elements:
         - 


### PR DESCRIPTION
# Migration
https://postgrowth-lab.uvigo.es/projects/prospera/
- passer en liste
- enlever le mode icones

## Layout grille
<img width="1918" height="957" alt="Capture d’écran 2026-04-29 à 16 38 21" src="https://github.com/user-attachments/assets/5005bd57-963b-4232-82e7-29290dc33037" />
<img width="1917" height="958" alt="Capture d’écran 2026-04-29 à 16 38 09" src="https://github.com/user-attachments/assets/a0983a07-06a2-4356-9c40-a9e85717aeea" />

## Layout liste
Avec images :
<img width="1917" height="956" alt="Capture d’écran 2026-04-29 à 16 39 17" src="https://github.com/user-attachments/assets/16728dcd-72c8-4170-9271-84d872b674b4" />
Sans image : 
<img width="1918" height="956" alt="Capture d’écran 2026-04-29 à 16 44 36" src="https://github.com/user-attachments/assets/cb6ab85b-754a-4f5b-9ca4-9b499d9cc8ce" />

----

Mobile OK